### PR TITLE
Refactoring main block component to match ember's media object component

### DIFF
--- a/source/_patterns/02-molecules/blocks/block-list-item.json
+++ b/source/_patterns/02-molecules/blocks/block-list-item.json
@@ -1,9 +1,12 @@
 {
-  "block_image": {
+  "block_media": {
     "img": {
       "src": "https://picsum.photos/100/100?image=350",
       "alt": "A Photo"
-    },
+    }
+  },
+
+  "block_object": {
     "kicker": "Food"
   },
 

--- a/source/_patterns/02-molecules/blocks/block-list-item.twig
+++ b/source/_patterns/02-molecules/blocks/block-list-item.twig
@@ -1,23 +1,2 @@
-<div class="c-block-item {{ block_classes }}">
-
-  {% if block_image %}
-    <div class="c-block-item__image">
-      <a href="">{% include '@atoms/images/image.twig' with block_image %}</a>
-
-      <div class="c-block__category">
-        {% include '@atoms/text/kicker.twig' with block_image %}
-      </div>
-
-    </div>
-  {% endif %}
-
-  <div class="c-block-item__text u-spacing">
-
-    <h3 class="c-block-item__title"><a href="">{{ block_title }}</a></h3>
-
-    {% if block_meta %}
-      {% include '@molecules/meta/block-meta.twig' with block_meta %}
-    {% endif %}
-
-  </div>
-</div>
+{% extends "block.twig" %}
+{% set block_classes = "c-block--item" %}

--- a/source/_patterns/02-molecules/blocks/block.json
+++ b/source/_patterns/02-molecules/blocks/block.json
@@ -1,8 +1,12 @@
 {
-  "block_image": {
+  "block_media": {
     "img": {
-      "src": "https://picsum.photos/400/250?image=350"
-    },
+      "src": "https://picsum.photos/400/250?image=250",
+      "alt": "My Media"
+    }
+  },
+
+  "block_object": {
     "kicker": "Food"
   },
 

--- a/source/_patterns/02-molecules/blocks/block.twig
+++ b/source/_patterns/02-molecules/blocks/block.twig
@@ -1,32 +1,35 @@
 <div class="c-block {{ block_classes }}">
 
-  {% if block_image %}
-    <div class="c-block__image">
-      <a href="">{% include '@atoms/images/image.twig' with block_image %}</a>
+  {% block block_media %}
+    {% if block_media %}
+      <div class="c-block__media">
+        <a href="">{% include '@atoms/images/image.twig' with block_media %}</a>
+      </div>
+    {% endif %}
+  {% endblock %}
 
-      <div class="c-block__category">
-        {% include '@atoms/text/kicker.twig' with block_image %}
+  {% block block_object %}
+    <div class="c-block__object u-spacing--half">
+
+      <div class="c-block__eyebrow">
+        {% include '@atoms/text/kicker.twig' with block_object %}
+      </div>
+
+      <h3 class="c-block__title"><a href="">{{ block_title }}</a></h3>
+
+      <div class="u-spacing">
+        {% if block_dek %}
+          <div class="c-block__dek o-rte-text">
+            <p>{{ block_dek }}</p>
+          </div>
+        {% endif %}
+
+        {% if block_meta %}
+          {% include '@molecules/meta/block-meta.twig' with block_meta %}
+        {% endif %}
       </div>
 
     </div>
-  {% endif %}
-
-  <div class="c-block__text u-spacing--quarter">
-
-    <h3 class="c-block__title"><a href="">{{ block_title }}</a></h3>
-
-    <div class="u-spacing">
-      {% if block_dek %}
-        <div class="c-block__dek o-rte-text">
-          <p>{{ block_dek }}</p>
-        </div>
-      {% endif %}
-
-      {% if block_meta %}
-        {% include '@molecules/meta/block-meta.twig' with block_meta %}
-      {% endif %}
-    </div>
-
-  </div>
+  {% endblock %}
 
 </div>

--- a/source/scss/_library/_objects.blocks.scss
+++ b/source/scss/_library/_objects.blocks.scss
@@ -20,7 +20,7 @@
     }
   }
 
-  &__text {
+  &__object {
     padding-top: $space-half;
   }
 }
@@ -29,11 +29,11 @@
 /**
  * Inline blocks (often used in lists)
  */
-.c-block-item {
+.c-block--item {
   display: flex;
   align-items: flex-start;
 
-  &__image {
+  .c-block__media {
     min-width: 100px;
     max-width: 100px;
     overflow: hidden;
@@ -44,20 +44,11 @@
     }
   }
 
-  &__title {
-    font-weight: bold;
+  .c-block__title {
     font-size: $font-size-s-m;
-
-    a {
-      color: $c-black;
-
-      &:hover {
-        color: $c-primary;
-      }
-    }
   }
 
-  &__text {
+  .c-block__object {
     padding: $space-half 0 0 $space;
     width: 100%;
   }


### PR DESCRIPTION
The content inside the `block.twig` component is default block content and both sections (`block_media` and `block_object`) can be completely rewritten if extended in another pattern. In this instance, `block-list-item.twig` can reuse those default elements. In more complex instances, we'll likely be injecting other components and other necessary elements.