### PR TITLE
Refactor lead to re use figure with caption

### DIFF
--- a/source/_patterns/02-molecules/leads/lead-gallery.twig
+++ b/source/_patterns/02-molecules/leads/lead-gallery.twig
@@ -1,0 +1,23 @@
+<div class="c-lead c-lead-gallery {{ lead_classes }}">
+
+  <div class="c-lead-gallery__top">
+
+    {% include '@molecules/article/figure-with-caption.twig' %}
+
+    <div class="c-lead-gallery__text">
+      <h2 class="c-lead-gallery__title">{{ lead_slides_title }}</h2>
+      <div class="c-lead-gallery__dek">
+        <p>{{ lead_slides_dek }}</p>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="c-lead-gallery__thumbs">
+    {% for slide in lead_slides %}
+      <a href="" class="c-lead-gallery__thumbs-thumb"><img src="{{ slide.src }}" alt="{{ slide.lead_slides_title }}" data-caption="{{ slide.lead_slides_dek }}" data-image="{{ slide.src_l }}"></a>
+    {% endfor %}
+    <a href="" class="c-lead-gallery__thumbs-thumb c-lead-gallery__thumbs-thumb-text u-font--secondary-style u-font--xs js-toggle" data-toggled="c-main" data-prefix="gallery">View all <span>15</span></a>
+  </div>
+
+</div>

--- a/source/_patterns/02-molecules/leads/lead.twig
+++ b/source/_patterns/02-molecules/leads/lead.twig
@@ -1,36 +1,3 @@
-<div class="c-lead {{ lead_classes }} {% if is_gallery %}c-lead-gallery{% endif %}">
-
-  <div class="c-lead__image">
-    {% include '@atoms/images/picture.twig' %}
-  </div>
-
-  {% if is_gallery %}
-    <div class="u-spacing">
-      <div class="c-lead-gallery__text">
-  {% endif %}
-
-  {% block lead_caption %}
-    {%
-      include '@molecules/article/caption.twig'
-      with {
-        "caption_classes": "c-lead__caption"
-      }
-    %}
-  {% endblock %}
-
-  {% if is_gallery %}
-        <h2 class="c-lead-gallery__title">{{ lead_slides_title }}</h2>
-        <div class="c-lead-gallery__dek">
-          <p>{{ lead_slides_dek }}</p>
-        </div>
-      </div>
-      <div class="c-lead-gallery__thumbs">
-        {% for slide in lead_slides %}
-          <a href="" class="c-lead-gallery__thumbs-thumb"><img src="{{ slide.src }}" alt="{{ slide.lead_slides_title }}" data-caption="{{ slide.lead_slides_dek }}" data-image="{{ slide.src_l }}"></a>
-        {% endfor %}
-        <a href="" class="c-lead-gallery__thumbs-thumb c-lead-gallery__thumbs-thumb-text u-font--secondary-style u-font--xs js-toggle" data-toggled="c-main" data-prefix="gallery">View all <span>15</span></a>
-      </div>
-    </div>
-  {% endif %}
-
+<div class="c-lead {{ lead_classes }} ">
+  {% include '@molecules/article/figure-with-caption.twig' %}
 </div>

--- a/source/_patterns/02-molecules/leads/lead~gallery.json
+++ b/source/_patterns/02-molecules/leads/lead~gallery.json
@@ -1,3 +1,0 @@
-{
-  "is_gallery": true
-}

--- a/source/_patterns/03-organisms/article/article-header.twig
+++ b/source/_patterns/03-organisms/article/article-header.twig
@@ -22,12 +22,11 @@
         {% include 'molecules-share-tools' %}
       </div>
 
-      {%
-        include 'molecules-lead'
-        with {
-          "lead_classes": "c-article__lead"
-        }
-      %}
+      {% if is_gallery %}
+        {% include 'molecules-lead-gallery' %}
+      {% else %}
+        {% include 'molecules-lead' %}
+      {% endif %}
     </div>
 
     <div class="c-article__related c-article__related--wide-screens">

--- a/source/scss/_library/_base.media.scss
+++ b/source/scss/_library/_base.media.scss
@@ -24,7 +24,6 @@ figure {
   position: relative;
   display: inline-block;
   overflow: hidden;
-  padding: $space 0;
 }
 
 figcaption {

--- a/source/scss/_library/_config.imports.scss
+++ b/source/scss/_library/_config.imports.scss
@@ -38,6 +38,7 @@
  * Touts................Promotional sections of content.
  * Sections.............Larger components of pages.
  * Forms................Specific form styling.
+ * Media................Specific media objects, e.g. figures
  *
  * TEXT
  * Text.................Various text-specific class definitions.
@@ -115,6 +116,7 @@ $tests: true;
 @import "objects.touts";
 @import "objects.sections";
 @import "objects.forms";
+@import "objects.media";
 
 /*------------------------------------*\
     $PAGE STRUCTURE

--- a/source/scss/_library/_module.article.scss
+++ b/source/scss/_library/_module.article.scss
@@ -25,7 +25,7 @@
   &__lead {
     position: relative;
 
-    .c-lead__image {
+    figure.o-figure {
       @include media('<=medium') {
         margin-left: -$space;
         margin-right: -$space;

--- a/source/scss/_library/_objects.leads.scss
+++ b/source/scss/_library/_objects.leads.scss
@@ -5,16 +5,6 @@
 .c-lead {
 }
 
-.o-figure__image,
-.c-lead__image {
-  border: 2px solid $c-black;
-  margin-bottom: $space-half;
-
-  img {
-    width: 100%;
-  }
-}
-
 /**
  * Gallery version of a lead
  */

--- a/source/scss/_library/_objects.leads.scss
+++ b/source/scss/_library/_objects.leads.scss
@@ -10,8 +10,8 @@
  */
 .c-lead-gallery {
 
-  .c-lead__image {
-    margin-bottom: 0;
+  figcaption.o-caption {
+    padding: 0 $space;
   }
 
   &__text {

--- a/source/scss/_library/_objects.leads.scss
+++ b/source/scss/_library/_objects.leads.scss
@@ -10,17 +10,20 @@
  */
 .c-lead-gallery {
 
+  &__top {
+    background-color: $c-octonary;
+    margin-bottom: $space;
+  }
+
   figcaption.o-caption {
     padding: 0 $space;
   }
 
   &__text {
-    background-color: $c-octonary;
     padding: $space-half $space $space;
   }
 
   &__title {
-    padding-top: $space-half;
     font-size: $font-size-m;
   }
 

--- a/source/scss/_library/_objects.media.scss
+++ b/source/scss/_library/_objects.media.scss
@@ -1,0 +1,16 @@
+/*------------------------------------*\
+    $MEDIA OBJECTS
+\*------------------------------------*/
+
+.o-figure {
+  display: block;
+}
+
+.o-figure__image {
+  border: 2px solid $c-black;
+  margin-bottom: $space-half;
+
+  img {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
two thing I tried to do here: 

1. use the existing `figure-with-caption` molecule in both the `lead` and `lead-gallery` molecules
2. update the `figure-with-caption` molecule with parent classes for the different contexts

Note this adds a new `lead-gallery` molecule in place of the `lead~gallery` pseudopattern.