### PR TITLE
merge `social-links` into `share-tools`

### DIFF
--- a/source/_patterns/02-molecules/social/share-tools.twig
+++ b/source/_patterns/02-molecules/social/share-tools.twig
@@ -1,4 +1,7 @@
 <div class="c-share-tools">
+  {% if label %}
+    <span class="c-share-tools__label u-font--secondary-style u-font--xs u-color--white">{{ label }}</span>
+  {% endif %}
   <div class="c-share-tools__group">
     <a href="" class="c-share-tools__link"><span class="o-icon u-icon--xs">{% include '@atoms/icons/icon-facebook.twig' %}</span></a>
     <a href="" class="c-share-tools__link"><span class="o-icon u-icon--xs">{% include '@atoms/icons/icon-twitter.twig' %}</span></a>

--- a/source/_patterns/02-molecules/social/share-tools.twig
+++ b/source/_patterns/02-molecules/social/share-tools.twig
@@ -3,10 +3,10 @@
     <span class="c-share-tools__label u-font--secondary-style u-font--xs u-color--white">{{ label }}</span>
   {% endif %}
   <div class="c-share-tools__group">
-    <a href="" class="c-share-tools__link"><span class="o-icon u-icon--xs">{% include '@atoms/icons/icon-facebook.twig' %}</span></a>
-    <a href="" class="c-share-tools__link"><span class="o-icon u-icon--xs">{% include '@atoms/icons/icon-twitter.twig' %}</span></a>
-    <a href="" class="c-share-tools__link"><span class="o-icon u-icon--s">{% include '@atoms/icons/icon-reddit.twig' %}</span></a>
-    <a href="" class="c-share-tools__link"><span class="o-icon u-icon--xs">{% include '@atoms/icons/icon-email.twig' %}</span></a>
+    <a href="" class="c-share-tools__link o-icon">{% include '@atoms/icons/icon-facebook.twig' %}</a>
+    <a href="" class="c-share-tools__link o-icon">{% include '@atoms/icons/icon-twitter.twig' %}</a>
+    <a href="" class="c-share-tools__link o-icon">{% include '@atoms/icons/icon-reddit.twig' %}</a>
+    <a href="" class="c-share-tools__link o-icon">{% include '@atoms/icons/icon-email.twig' %}</a>
   </div>
   {#
     <div class="c-share-tools__extra">

--- a/source/_patterns/02-molecules/social/share-tools.twig
+++ b/source/_patterns/02-molecules/social/share-tools.twig
@@ -1,4 +1,4 @@
-<div class="c-share-tools">
+<div class="c-share-tools {% if is_vertical %}c-share-tools--vertical{% endif %}">
   {% if label %}
     <span class="c-share-tools__label u-font--secondary-style u-font--xs u-color--white">{{ label }}</span>
   {% endif %}

--- a/source/_patterns/02-molecules/social/share-tools~vertical.json
+++ b/source/_patterns/02-molecules/social/share-tools~vertical.json
@@ -1,0 +1,3 @@
+{
+  "is_vertical": true
+}

--- a/source/_patterns/03-organisms/global/footer.twig
+++ b/source/_patterns/03-organisms/global/footer.twig
@@ -19,7 +19,10 @@
             <a href="" class="c-main-footer__send-story u-font--secondary-style u-font--xs"><strong>Send Us a Story Idea</strong></a>
 
             <div class="c-main-footer__social">
-              {% include '@molecules/social/brand-social-links.twig' %}
+              {%
+                include '@molecules/social/share-tools.twig'
+                with { label: 'Follow Us' }
+              %}
             </div>
           </div>
 

--- a/source/_patterns/03-organisms/global/side-menu.twig
+++ b/source/_patterns/03-organisms/global/side-menu.twig
@@ -22,7 +22,10 @@
     %}
 
     <div class="c-side-menu__social">
-      {% include '@molecules/social/brand-social-links.twig' %}
+      {%
+        include '@molecules/social/share-tools.twig'
+        with { label: 'Follow Us' }
+      %}
     </div>
 
   </div>

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -221,4 +221,21 @@
     });
   })();
 
+  // switch share tools orientation in article header
+  (function() {
+    const BREAKPOINT = '(min-width: 769px)'; // <= 768px
+    let toolsInHeader = document.querySelector('.c-article__header .c-share-tools');
+    if (!toolsInHeader) {
+      return;
+    }
+
+    const toggle = e => toolsInHeader.classList.toggle('c-share-tools--vertical', e.matches);
+    const mql = window.matchMedia(BREAKPOINT);
+
+    // when the screen crosses the breakpoint, toggle the vertical orientation based on whether
+    // the media query matches or not
+    mql.addListener(toggle);
+    toggle(mql);
+  })();
+
 })(jQuery);

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -206,7 +206,8 @@
 
   // Slide in headers
   (function() {
-    var distance = $('.c-article').offset().top,
+    var offset = $('.c-article').offset(),
+        distance = offset ? offset.top : 0,
         $window = $(window);
 
     $window.scroll(function() {

--- a/source/scss/_library/_module.article.scss
+++ b/source/scss/_library/_module.article.scss
@@ -43,7 +43,7 @@
   @include media('<=medium') {
     background: none;
     margin-bottom: $space-and-half;
-    margin-left: -13px; // Arbitrary number to adjust for left alignment - https://cl.ly/4286d2bc8efc
+    margin-left: -6px; // Arbitrary number to adjust for left alignment - https://cl.ly/4286d2bc8efc
   }
 
   @include media('>medium') {

--- a/source/scss/_library/_module.article.scss
+++ b/source/scss/_library/_module.article.scss
@@ -54,63 +54,6 @@
     left: -($col-width * 2) + ($gutter * 2) + px;
   }
 }
-.c-share-tools {
-
-  &__link {
-    align-items: center;
-    justify-content: center;
-
-    path {
-      transition: all 0.25s ease-in-out;
-    }
-
-    &:hover {
-      path {
-        fill: $c-primary;
-      }
-    }
-
-    @include media('<=medium') {
-      height: 36px;
-      width: 40px;
-      display: inline-flex;
-    }
-
-    @include media('>medium') {
-      display: flex;
-      width: 100%;
-      height: 37px;
-    }
-  }
-
-  &__group {
-    @include media('<=medium') {
-      display: inline-block;
-    }
-  }
-
-  &__extra {
-
-    @include media('<=medium') {
-      display: inline-block;
-      padding-left: $space-half;
-      margin-left: $space-half;
-      background-image: linear-gradient(to bottom, transparent 50%, $c-gray 50%);
-      background-position: left center;
-      background-size: 1px 16px;
-      background-repeat: repeat-y;
-    }
-
-    @include media('>medium') {
-      margin-top: $space-half;
-      padding-top: $space-half;
-      background-image: linear-gradient(to right, transparent 50%, $c-gray 50%);
-      background-position: center top;
-      background-size: 16px 1px;
-      background-repeat: repeat-x;
-    }
-  }
-}
 
 /**
  * Related content

--- a/source/scss/_library/_module.footer.scss
+++ b/source/scss/_library/_module.footer.scss
@@ -34,22 +34,8 @@
       justify-content: flex-start;
     }
 
-    .c-brand-social {
-
-      @include media('<=small') {
-        flex-wrap: wrap;
-        margin-bottom: -18px;
-
-        &__label {
-          width: 100%;
-          display: block;
-          margin-bottom: 2px;
-        }
-
-        &__link:first-of-type {
-          margin-left: -6px;
-        }
-      }
+    .c-share-tools {
+      fill: white;
     }
   }
 

--- a/source/scss/_library/_module.header.scss
+++ b/source/scss/_library/_module.header.scss
@@ -269,13 +269,16 @@
     }
   }
 
-  .c-brand-social {
-    justify-content: center;
-  }
-
   &__branding {
     width: 180px;
     margin: $space-half auto $space-half;
+  }
+
+  &__social {
+    .c-share-tools {
+      fill: white;
+      justify-content: center;
+    }
   }
 
   &__secondary-nav {
@@ -355,34 +358,6 @@
 
     @include media('>medium') {
       transform: translateX(500px);
-    }
-  }
-}
-
-
-/**
- * Brand social links in the side menu
- */
-.c-brand-social {
-  display: flex;
-  align-items: center;
-
-  &__label {
-    margin-right: $space-half;
-  }
-
-  &__link {
-    width: 30px;
-    height: 30px;
-    padding: 5px;
-    margin: 0 4px;
-
-    @include media('>small') {
-      width: 40px;
-    }
-
-    path {
-      fill: $c-white;
     }
   }
 }

--- a/source/scss/_library/_objects.components.scss
+++ b/source/scss/_library/_objects.components.scss
@@ -177,4 +177,26 @@
       margin: 4px 0;
     }
   }
+
+  &__extra {
+
+    @include media('<=medium') {
+      display: inline-block;
+      padding-left: $space-half;
+      margin-left: $space-half;
+      background-image: linear-gradient(to bottom, transparent 50%, $c-gray 50%);
+      background-position: left center;
+      background-size: 1px 16px;
+      background-repeat: repeat-y;
+    }
+
+    @include media('>medium') {
+      margin-top: $space-half;
+      padding-top: $space-half;
+      background-image: linear-gradient(to right, transparent 50%, $c-gray 50%);
+      background-position: center top;
+      background-size: 16px 1px;
+      background-repeat: repeat-x;
+    }
+  }
 }

--- a/source/scss/_library/_objects.components.scss
+++ b/source/scss/_library/_objects.components.scss
@@ -167,6 +167,14 @@
     }
   }
 
+
+  &:not(&--vertical) {
+    .c-share-tools__link {
+    }
+    .c-share-tools__group {
+    }
+  }
+
   &--vertical {
     .c-share-tools__group {
       flex-wrap: wrap;

--- a/source/scss/_library/_objects.components.scss
+++ b/source/scss/_library/_objects.components.scss
@@ -106,3 +106,29 @@
     background-color: $c-quaternary;
   }
 }
+
+.c-share-tools {
+
+  &__group {
+    display: flex;
+    align-items: center;
+  }
+
+  &__link {
+    width: 30px;
+    height: 30px;
+    padding: 5px;
+    margin: 0 4px;
+
+
+    path {
+      transition: all 0.25s ease-in-out;
+    }
+
+    &:hover {
+      path {
+        fill: $c-primary;
+      }
+    }
+  }
+}

--- a/source/scss/_library/_objects.components.scss
+++ b/source/scss/_library/_objects.components.scss
@@ -127,6 +127,10 @@
     margin: 0 4px;
 
 
+    @include media('>small') {
+      width: 40px;
+    }
+
     path {
       transition: all 0.25s ease-in-out;
     }
@@ -135,6 +139,31 @@
       path {
         fill: $c-primary;
       }
+    }
+  }
+
+  @include media('<=small') {
+    flex-wrap: wrap;
+
+    &__label {
+      flex-basis: 100%;
+      margin: 0 0 2px 0;
+
+      + .c-share-tools__group > .c-share-tools__link:first-of-type {
+        margin-left: -5px; // align first icon with label if present
+      }
+    }
+
+    &__link {
+      margin: 0;
+    }
+
+    &__group {
+      flex-wrap: wrap;
+    }
+
+    &__group > * + * {
+      margin: 0 0 0 $space-quarter;
     }
   }
 

--- a/source/scss/_library/_objects.components.scss
+++ b/source/scss/_library/_objects.components.scss
@@ -108,6 +108,12 @@
 }
 
 .c-share-tools {
+  display: flex;
+  align-items: center;
+
+  &__label {
+    margin-right: $space-half;
+  }
 
   &__group {
     display: flex;

--- a/source/scss/_library/_objects.components.scss
+++ b/source/scss/_library/_objects.components.scss
@@ -137,4 +137,15 @@
       }
     }
   }
+
+  &--vertical {
+    .c-share-tools__group {
+      flex-wrap: wrap;
+    }
+
+    .c-share-tools__link {
+      flex-basis: 100%;
+      margin: 4px 0;
+    }
+  }
 }

--- a/source/scss/_library/_objects.icons.scss
+++ b/source/scss/_library/_objects.icons.scss
@@ -7,6 +7,11 @@
  */
 .o-icon {
   display: inline-block;
+
+  svg,
+  path {
+    fill: inherit;
+  }
 }
 
 .o-text-with-icon {


### PR DESCRIPTION
Visually, these two molecules are very similar, and the behavior can be easily controlled via developer usage in ember.

I was able to reduce the amount of contextual rules by setting up some sane defaults for responsive styles.

The vertical orientation is controlled via a class, and there's a small media query listener that will run on templates that have an article header organism present.