### PR TITLE
why does the form field group have such a high z index?

### DIFF
--- a/source/scss/_library/_objects.forms.scss
+++ b/source/scss/_library/_objects.forms.scss
@@ -225,7 +225,6 @@
     display: flex;
     border: 3px solid $c-border-color;
     position: relative;
-    z-index: $z-index-newsletter-fields;
   }
 
   &__input {


### PR DESCRIPTION
It ends up peeking through the gallery overlay on my end.