### PR TITLE
Make recirc-tout a block-group modifier

### DIFF
--- a/source/_patterns/03-organisms/sections/block-list-group-1col-with-heading-block.twig
+++ b/source/_patterns/03-organisms/sections/block-list-group-1col-with-heading-block.twig
@@ -1,5 +1,5 @@
 {% extends "block-list-group.twig" %}
-{% set block_group_classes = "c-block-group--with-ad c-block-group--single-col" %}
+{% set block_group_classes = "c-block-group--single-col" %}
 
 {% block feature_first_block %}
   {% include '@molecules/blocks/block.twig' with feature_first_block %}

--- a/source/_patterns/03-organisms/sections/block-list-group-with-300x600-ad.twig
+++ b/source/_patterns/03-organisms/sections/block-list-group-with-300x600-ad.twig
@@ -1,5 +1,5 @@
 {% extends "block-list-group.twig" %}
-{% set block_group_classes = "c-block-group--with-ad" %}
+{% set block_group_classes = "c-block-group--right-rail" %}
 
 {% block feature_first_block %}{% endblock %}
 {% block feature_last_block %}{% endblock %}

--- a/source/_patterns/03-organisms/sections/block-list-group-with-ad.twig
+++ b/source/_patterns/03-organisms/sections/block-list-group-with-ad.twig
@@ -1,5 +1,5 @@
 {% extends "block-list-group.twig" %}
-{% set block_group_classes = "c-block-group--with-ad" %}
+{% set block_group_classes = "c-block-group--right-rail" %}
 
 {% block feature_first_block %}{% endblock %}
 {% block feature_last_block %}{% endblock %}

--- a/source/_patterns/03-organisms/sections/block-list-group-with-footer-block-and-ad.twig
+++ b/source/_patterns/03-organisms/sections/block-list-group-with-footer-block-and-ad.twig
@@ -1,5 +1,5 @@
 {% extends "block-list-group.twig" %}
-{% set block_group_classes = "c-block-group--with-ad c-block-group--with-footer-block" %}
+{% set block_group_classes = "c-block-group--right-rail c-block-group--with-footer-block" %}
 
 {% block feature_first_block %}{% endblock %}
 {% block feature_last_block %}

--- a/source/_patterns/03-organisms/touts/recirculation.twig
+++ b/source/_patterns/03-organisms/touts/recirculation.twig
@@ -1,13 +1,13 @@
-<section class="c-recirc-tout o-section">
+<section class="c-block-group c-block-group--offset o-section">
 
-  <div class="c-recirc-tout__col1 u-spacing--and-half">
+  <div class="c-block-group__col1 u-spacing--and-half">
     <h2 class="o-section__heading o-bg-text-accent">Recent Stories</h2>
     {% block recirc_list %}
       {% include '@molecules/lists/block-list.twig' with recirc_list %}
     {% endblock %}
   </div>
 
-  <div class="c-recirc-tout__col2 u-spacing--and-half">
+  <div class="c-block-group__col2 u-spacing--and-half">
     <h2 class="o-section__heading o-bg-text-accent">Featured Story</h2>
     {% block recirc_block %}
       {% include '@molecules/blocks/block.twig' with recirc_block %}

--- a/source/scss/_library/_objects.sections.scss
+++ b/source/scss/_library/_objects.sections.scss
@@ -13,34 +13,6 @@
 }
 
 /**
- * Recirculation
- */
-.c-recirc-tout {
-  padding: $space-double 0;
-
-  @include media('>medium') {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-  }
-
-  &__col1 {
-    margin-bottom: $space-triple;
-    @include media('>medium') {
-      margin-bottom: 0;
-      width: calc(56% - #{$space});
-    }
-  }
-
-  &__col2 {
-    @include media('>medium') {
-      width: calc(44% - #{$space});
-    }
-  }
-}
-
-
-/**
  * Block group
  */
 .c-block-group {
@@ -67,7 +39,7 @@
   }
 
   // With ad
-  &--with-ad {
+  &--right-rail {
     @include media('<=medium') {
       display: flex;
       flex-wrap: wrap;
@@ -86,6 +58,10 @@
     .c-block-group__col1 {
       width: 100%;
       padding: 0;
+
+      @include media('>medium') {
+        padding: 0; // override base style
+      }
 
       > .c-block {
         margin-bottom: $space-triple;
@@ -115,6 +91,26 @@
       @include media('>small') {
         margin-bottom: 0;
         max-width: calc(50% - #{$space-half});
+      }
+    }
+  }
+
+  &--offset {
+    padding: $space-double 0;
+
+    .c-block-group__col1 {
+      margin-bottom: $space-triple;
+
+      @include media('>medium') {
+        padding-right: 0;
+        margin-bottom: 0;
+        width: calc(56% - #{$space});
+      }
+    }
+
+    .c-block-group__col2 {
+      @include media('>medium') {
+        width: calc(44% - #{$space});
       }
     }
   }
@@ -374,4 +370,3 @@
     }
   }
 }
-


### PR DESCRIPTION
Looking at the CSS, the rules for the `c-recirc-tout` block have a lot of overlap with the `c-block-group` block, so I'd like to make it a modifier.

It'll make the code easier to maintain on my end and arguably easier to reason about if we have a single block layout organism that has multiple variations that can be configured with a single class modifier.