### PR TITLE
force images to resize within a 3:2 aspect ratio

### DIFF
--- a/source/scss/_library/_objects.leads.scss
+++ b/source/scss/_library/_objects.leads.scss
@@ -116,3 +116,34 @@
     }
   }
 }
+
+// force "active" gallery image into a 3:2 ratio
+.c-lead-gallery__top {
+  .o-picture {
+    position: relative;
+
+    &:before {
+      content: '';
+      display: block;
+      padding-top: (2 / 3) * 100%;
+      width: 100%;
+    }
+
+    > img {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+
+      width: auto;
+      height: auto;
+      max-width: 100%;
+      max-height: 100%;
+
+      margin: auto;
+
+      object-fit: contain;
+    }
+  }
+}


### PR DESCRIPTION
I'd prefer to use `object-fit: contain`, but... IE

[ticket](https://jira.wnyc.org/browse/DS-166)