### PR TITLE
make this heading semantically meaningless

### DIFF
--- a/source/_patterns/02-molecules/meta/header-article-meta.twig
+++ b/source/_patterns/02-molecules/meta/header-article-meta.twig
@@ -9,7 +9,7 @@
   </div>
 
   {% if headline %}
-    <h1 class="c-main-header__title u-truncate">{{ headline }}</h1>
+    <span class="c-main-header__title u-truncate">{{ headline }}</span>
   {% endif %}
 
 </div>

--- a/source/scss/_library/_module.header.scss
+++ b/source/scss/_library/_module.header.scss
@@ -96,6 +96,7 @@
     color: $c-white;
     font-weight: normal;
     line-height: 1.2;
+    letter-spacing: 1px;
     padding: 0 $space-double 0 $space;
 
     @include media('>medium') {


### PR DESCRIPTION
article templates already have an `h1` in the article header organism,
and there should only bre one h1 on a page.

I made this update on the website, but I want pattern lab in sync. Plus
the letter spacing rule is inherited from h1, and needs to be expclitly
set on this element now.

[ticket](https://jira.wnyc.org/browse/DS-77)