### PR TITLE
sarch icon fill color

### DIFF
--- a/source/scss/_library/_objects.forms.scss
+++ b/source/scss/_library/_objects.forms.scss
@@ -137,6 +137,10 @@
   .c-search__button {
     opacity: 1;
     transition: opacity .1s ease-out;
+
+    .search-icon {
+      fill: $c-black;
+    }
   }
 }
 


### PR DESCRIPTION
[DS-240]

I know this seems nit picky, but I want this component to be agnostic of its context. As it is there's already some expectations embedded in the code that it should always be in the upper right of the page.

In the ember app, I've attempted to nudge this towards being less contextually sensitive by using the more generic `.is-open` class, instead of the `.top-search-is-active` class. I see that you're using data attributes to toggle some DOM state, which is a bit limited when it comes to generic state handlers, so I didn't want to open up a big refactor of the JS utils you're using.

For now, we can have some duplicate rules, but at some point I'd like to revisit certain components so class names and CSS rules don't specify things like page position.