### PR TITLE
add'l scope for homepage header style

### DIFF
--- a/source/scss/themes/default/_theme.overrides.scss
+++ b/source/scss/themes/default/_theme.overrides.scss
@@ -15,7 +15,7 @@
       }
     }
 
-    .c-main-header__branding {
+    &:not(.out-of-viewport) .c-main-header__branding {
       width: 110px;
       position: relative;
       bottom: -$space;


### PR DESCRIPTION
in the app, there's only 1 header element, so add this `:not` selector 
to scope the offset stylings to only when the header is in the initial 
state