### PR TITLE
Update billboard to support mobile leaderboard ad size (320x50)

### DIFF
--- a/source/_data/data.json
+++ b/source/_data/data.json
@@ -20,7 +20,7 @@
   "has_ad": true,
 
   "ads": {
-    "small": "https://s0.2mdn.net/5188901/TINCUP_OUTSIDEONLINE_300x50.jpg",
+    "small": "https://s0.2mdn.net/6634941/19-1538-A-AprEss-Offer-ST-320x50-OFF1.jpg",
     "medium": "https://tpc.googlesyndication.com/simgad/3866766746825522936",
     "large": "https://s0.2mdn.net/8766144/CWDisplayAds_OutsideHPTO_970x250.jpg"
   },

--- a/source/scss/_library/_module.main.scss
+++ b/source/scss/_library/_module.main.scss
@@ -49,7 +49,7 @@
 
   // Billboard progression
   &--billboard {
-    width: 300px;
+    width: 320px;
 
     @include media('>750px') {
       width: 728px;


### PR DESCRIPTION
Update billboard to support mobile leaderboard ad size (320x50)

When this was 300, 320x50 ads would get 20 pixels cut off of the sides