### PR TITLE
some banner suggestions

### DIFF
--- a/source/_patterns/02-molecules/banners/box-banner.json
+++ b/source/_patterns/02-molecules/banners/box-banner.json
@@ -2,5 +2,6 @@
   "banner_classes": "o-3d-heading--quinary",
   "banner_title": "Long Wrapping Linked Headline Goes Here Now.",
   "banner_dek": "A coalition of community groups are <a href=\"\">suing the city</a> to stop a multi-billion dollar mega development of four high-rise towers that some locals fear will greatly.",
-  "banner_cta": true
+  "banner_cta": true,
+  "banner_link": true
 }

--- a/source/_patterns/02-molecules/banners/box-banner.twig
+++ b/source/_patterns/02-molecules/banners/box-banner.twig
@@ -1,4 +1,4 @@
-<div class="o-box-banner u-spacing o-3d-heading {{ not banner_dek and not banner_cta ? 'o-box-banner--title-only' }} {{ banner_classes }}">
+<div class="o-box-banner u-spacing o-3d-heading {{ banner_classes }}">
 
   <button class="o-box-banner__close js-toggle-parent"><span class="o-icon u-icon--xs o-icon--close">{% include '@atoms/icons/icon-close.twig' %}</span></button>
 

--- a/source/_patterns/02-molecules/banners/box-banner.twig
+++ b/source/_patterns/02-molecules/banners/box-banner.twig
@@ -2,7 +2,13 @@
 
   <button class="o-box-banner__close js-toggle-parent"><span class="o-icon u-icon--xs o-icon--close">{% include '@atoms/icons/icon-close.twig' %}</span></button>
 
-  <h3 class="o-box-banner__title"><a class="o-box-banner__title-link u-has-accent-inline" href="">{{ banner_title }}</a></h3>
+  <h3 class="o-box-banner__title">
+    {% if banner_link %}
+      <a href="">{{ banner_title }}</a>
+    {% else %}
+      {{ banner_title }}
+    {% endif %}
+  </h3>
 
   {% if banner_dek or banner_cta %}
     <div class="o-box-banner__group u-spacing">

--- a/source/_patterns/02-molecules/banners/box-banner~title-only.json
+++ b/source/_patterns/02-molecules/banners/box-banner~title-only.json
@@ -1,5 +1,6 @@
 {
   "banner_title": "Long Wrapping Linked Headline Goes Here Now.",
   "banner_dek": false,
-  "banner_cta": false
+  "banner_cta": false,
+  "banner_link": false
 }

--- a/source/_patterns/02-molecules/banners/text-banner.json
+++ b/source/_patterns/02-molecules/banners/text-banner.json
@@ -1,6 +1,0 @@
-{
-  "kicker": "Breaking News",
-  "banner_title": "Families Say NYPD Victim-Blaming Compounds Grief",
-  "banner_dek": "A <a href=\"\">coalition of community groups</a> are suing the city to stop a multi-billion dollar mega development.",
-  "timestamp": "Just Now"
-}

--- a/source/_patterns/02-molecules/banners/text-banner.twig
+++ b/source/_patterns/02-molecules/banners/text-banner.twig
@@ -1,23 +1,2 @@
 <div class="o-text-banner u-spacing--half">
-
-  {% if kicker %}
-    <div class="o-text-banner__eyebrow">
-      {% include '@atoms/text/kicker.twig' with { "remove_link": true } %}
-    </div>
-  {% endif %}
-
-  <div class="u-no-space">
-
-    <h3 class="o-text-banner__title"><a class="o-text-banner__title-link" href="">{{ banner_title }}</a></h3>
-
-    <div class="u-spacing--quarter">
-      {% if banner_dek and timestamp %}
-        <div class="o-text-banner__dek o-rte-text">
-          <p><span class="o-text-banner__timestamp u-font--secondary-style u-font--xs u-color--secondary">{{ timestamp }}</span> {{ banner_dek }}</p>
-        </div>
-      {% endif %}
-    </div>
-
-  </div>
-
 </div>

--- a/source/_patterns/02-molecules/banners/text-banner.twig
+++ b/source/_patterns/02-molecules/banners/text-banner.twig
@@ -1,2 +1,3 @@
 <div class="o-text-banner u-spacing--half">
+  {% include 'molecules-urgent-block' %}
 </div>

--- a/source/_patterns/02-molecules/blocks/block.twig
+++ b/source/_patterns/02-molecules/blocks/block.twig
@@ -27,12 +27,14 @@
 
       <{{ is_h2 ? 'h2' : 'h3' }} class="c-block__title {{ block_title_classes }}"><a class="c-block__title-link" href="">{{ block_title }}</a></{{ is_h2 ? 'h2' : 'h3' }}>
 
-      <div class="u-spacing--quarter">
-        {% if block_dek %}
-          <div class="c-block__dek o-rte-text">
-            <p>{{ block_dek }}</p>
-          </div>
-        {% endif %}
+      <div class="c-block__body u-spacing--quarter">
+        {% block block_dek %}
+          {% if block_dek %}
+            <div class="c-block__dek o-rte-text">
+              <p>{{ block_dek }}</p>
+            </div>
+          {% endif %}
+        {% endblock %}
 
         {% block block_meta %}
           {% if block_meta %}

--- a/source/_patterns/02-molecules/blocks/urgent-block.json
+++ b/source/_patterns/02-molecules/blocks/urgent-block.json
@@ -1,0 +1,5 @@
+{
+  "kicker": "breaking news",
+  "block_title": "Families Say NYPD Victim-Blaming Compounds Grief",
+  "block_dek": "A <a href=\"\">coalition of community groups</a> are suing the city to stop a multi-billion dollar mega development."
+}

--- a/source/_patterns/02-molecules/blocks/urgent-block.twig
+++ b/source/_patterns/02-molecules/blocks/urgent-block.twig
@@ -1,0 +1,17 @@
+{% extends "block.twig" %}
+
+{% set block_classes = "c-block--urgent" %}
+
+{% set block_media = false %}
+{% set remove_link = true %}
+{% set block_meta = false %}
+
+{% block block_dek %}
+  {% include 'molecules-block-meta' with {
+    timestamp: 'Just Now',
+    comment_count: false,
+  } %}
+  <div class="c-block__dek o-rte-text">
+    <p>{{ block_dek }}</p>
+  </div>
+{% endblock %}

--- a/source/scss/_library/_base.links.scss
+++ b/source/scss/_library/_base.links.scss
@@ -56,7 +56,7 @@ a {
 }
 
 // Used for line wrapping text links.
-.u-has-accent-inline {
+@mixin inline-accent {
   line-height: 1.6;
   display: inline;
   background-image: linear-gradient(to right, transparent 55%, $c-body-color 45%);
@@ -73,4 +73,8 @@ a {
     color: $c-white;
     background-color: $c-primary;
   }
+}
+
+.u-has-accent-inline {
+  @include inline-accent;
 }

--- a/source/scss/_library/_objects.blocks.scss
+++ b/source/scss/_library/_objects.blocks.scss
@@ -87,6 +87,40 @@
   }
 }
 
+.c-block--urgent {
+
+  .c-block__eyebrow > .o-kicker {
+    background-color: $c-gray--dark;
+    color: $c-white;
+  }
+
+  .c-block__title {
+    font-weight: bold;
+    font-size: $font-size-m;
+
+    @include media('>large') {
+      font-size: $font-size-xl;
+    }
+
+    a {
+      color: $c-secondary;
+      &:hover {
+        @include block-hover;
+      }
+    }
+  }
+
+  .c-block__body {
+    display: flex;
+    align-items: flex-end;
+  }
+
+  .c-block-meta__timestamp {
+    margin-right: $space-half;
+    color: $c-secondary;
+  }
+}
+
 
 /**
  * Inline blocks (often used in lists)

--- a/source/scss/_library/_objects.messaging.scss
+++ b/source/scss/_library/_objects.messaging.scss
@@ -48,16 +48,7 @@
 
   @include media('>large') {
     display: flex;
-  }
-
-  &--title-only {
-    display: block;
-    padding: $space-and-half;
-
-    .o-box-banner__title {
-      margin-top: 0;
-      text-align: center;
-    }
+    justify-content: center;
   }
 
   &.this-is-active {
@@ -76,7 +67,6 @@
 
     @include media('>large') {
       font-size: $font-size-m;
-      width: 100%;
       text-align: right;
     }
   }

--- a/source/scss/_library/_objects.messaging.scss
+++ b/source/scss/_library/_objects.messaging.scss
@@ -6,37 +6,10 @@
  * Text only banner message
  */
 .o-text-banner {
-  @include media('>large') {
-    padding-top: $space;
-  }
-
-  &__eyebrow .o-kicker {
-    background-color: $c-gray--dark;
-    color: $c-white;
-  }
-
-  &__title {
-    font-weight: bold;
-    font-size: $font-size-m;
-
-    @include media('>large') {
-      font-size: $font-size-xl;
-    }
-
-    a {
-      &:hover {
-        @include block-hover;
-      }
-    }
-  }
-
-  &__timestamp {
-    display: inline-block;
-    vertical-align: text-bottom;
-    margin-right: $space-half;
-  }
+ @include media('>large') {
+   padding-top: $space;
+ }
 }
-
 
 /**
  * Boxed in banner

--- a/source/scss/_library/_objects.messaging.scss
+++ b/source/scss/_library/_objects.messaging.scss
@@ -71,7 +71,10 @@
     }
   }
 
+  &__title > a,
   &__title-link {
+    @include inline-accent;
+
     &:hover {
       color: $c-body-color;
       background-color: transparent;


### PR DESCRIPTION
I refactored the `box-banner` and `text-banner` molecules. Please take a moment to read through my commits and give me your thoughts.

`box-banner`
the main changes here were to remove relying on special classes for the desired UI. I'd like to make it so that end-users don't need to remember to include classes for certain styling.

`text-banner`
This was more of an overhaul. In my eyes that the contents of the `text-banner` as they've been designed are essentially a variation on the existing `block` molecule. I made some edits to `block` so it could be extended with a few simple arguments and refactored the `text-banner` to use these variations, which I'm encapsulating under the name `urgent-block`, based on the fact that the font is red, which implies urgency.

Also there's a commit in here where I'm using a sass mixin; I'd like to start using more of these, because it helps us get closer to the idea of making the design system pieces more composable.