### PR TITLE
reset the image height to `initial`

### DIFF
--- a/source/scss/_library/_module.gallery.scss
+++ b/source/scss/_library/_module.gallery.scss
@@ -39,6 +39,7 @@
   }
 
   &__image img {
+    height: initial; // allows images with height attributes to occupy vertical space while loading
     max-height: 733px;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
when images are loading, if this isn't set to `initial`, the images will
collapse to zero height. I need their height to be consistent at load so
I can take some measurements for things lik the progress bar and
background.

part of [DS-310](https://jira.wnyc.org/browse/DS-310)