### PR TITLE
minor author block tweak

### DIFF
--- a/source/_patterns/02-molecules/blocks/author-block.twig
+++ b/source/_patterns/02-molecules/blocks/author-block.twig
@@ -9,7 +9,9 @@
         {% if author_block_role %}
           <span class="c-author-block__role u-font--secondary-style u-color--gray u-font--xs"><strong>{{ author_block_role }}</strong></span>
         {% endif %}
-        <a href="" class="c-author-block__details u-font--secondary-style u-has-accent u-has-accent--secondary u-font--xs">Articles</a>
+        <span class="c-author-block__details">
+          <a href="" class="u-font--secondary-style u-has-accent u-has-accent--secondary u-font--xs">Articles</a>
+        </span>
       </div>
 
       <div class="c-author-block__social">

--- a/source/scss/_library/_objects.blocks.scss
+++ b/source/scss/_library/_objects.blocks.scss
@@ -270,7 +270,8 @@ $author-media-width-l: 360;
   &__details {
     &:before {
       @include media('>small') {
-        @include dot-divider;
+        @include dot-divider($font-size: 24px);
+        line-height: 1;
         margin: 0 $space-half;
       }
     }

--- a/source/scss/_library/_objects.blocks.scss
+++ b/source/scss/_library/_objects.blocks.scss
@@ -256,16 +256,6 @@ $author-media-width-l: 360;
     }
   }
 
-  &__role {
-
-    &:after {
-      @include media('>small') {
-        @include dot-divider;
-        margin: 0 $space-half;
-      }
-    }
-  }
-
   &__social {
 
     @include media('>small') {
@@ -278,6 +268,13 @@ $author-media-width-l: 360;
   }
 
   &__details {
+    &:before {
+      @include media('>small') {
+        @include dot-divider;
+        margin: 0 $space-half;
+      }
+    }
+
     @include media('<=small') {
       position: absolute;
       right: 0;

--- a/source/scss/themes/default/_theme.mixins.scss
+++ b/source/scss/themes/default/_theme.mixins.scss
@@ -49,13 +49,15 @@
   // background-size: 12px 2px;
 }
 
-@mixin dot-divider {
+@mixin dot-divider(
+  $font-size: 18px,
+) {
   content: "•";
   display: inline-block;
   margin-right: $space-half;
   margin-left: -$space-quarter;
   color: $c-gray;
-  font-size: 18px;
+  font-size: $font-size;
   transform: translateY(.08em);
 }
 


### PR DESCRIPTION
put the `dot-divider` in `c-author-block__details` because it's an optional element, and my hunch is that the dot should only be displayed if there's content on both sides.

when an author (or staff member) doesn't have articles (e.g. ad sales people), there's no "articles" link shown.

[DS-327](https://jira.wnyc.org/browse/DS-327)