### PR TITLE
make sure the title has spacing

### DIFF
--- a/source/_patterns/02-molecules/banners/box-banner.twig
+++ b/source/_patterns/02-molecules/banners/box-banner.twig
@@ -2,7 +2,7 @@
 
   <button class="o-box-banner__close js-toggle-parent"><span class="o-icon u-icon--xs o-icon--close">{% include '@atoms/icons/icon-close.twig' %}</span></button>
 
-  <h3 class="o-box-banner__title">
+  <h3 class="o-box-banner__title u-space--top">
     {% if banner_link %}
       <a href="">{{ banner_title }}</a>
     {% else %}


### PR DESCRIPTION
I can imagine a world where we render this box without including a close
button, so I added this class to the title so that the spacing is
maintained, even if the lobotomized owl selector chain is broken with
the absence of the close button.