### PR TITLE
scope in this line height a bit

### DIFF
--- a/source/scss/_library/_objects.blocks.scss
+++ b/source/scss/_library/_objects.blocks.scss
@@ -199,6 +199,7 @@
  * Block meta
  */
 .c-block-meta {
+  line-height: 1.3;
 
   > * + * {
     &:before {


### PR DESCRIPTION
for the breaking news banner (and possibly other uses of the block).

The line height for this is inherited from way up on the `body` tag. Wondering if you wouldn't mind scoping this down a bit; I'm getting conflicts on the ember side when displaying the component in a non-gothamist context.