### PR TITLE
Moving o-credit style fixes to the Gallery Overlay

### DIFF
--- a/source/scss/_library/_module.gallery.scss
+++ b/source/scss/_library/_module.gallery.scss
@@ -7,6 +7,18 @@
   color: $c-white;
   background-color: $c-dark-bg;
 
+  .o-credit {
+    a {
+      color: $c-white;
+      border-bottom: 2px dotted $c-white;
+
+      &:hover {
+        color: $c-white;
+        background-color: $c-primary;
+      }
+    }
+  }
+
   .o-rte-text {
     a:visited {
       color: $c-white;
@@ -18,6 +30,8 @@
       padding: 0;
     }
   }
+
+
 }
 
 .c-slides {

--- a/source/scss/_library/_objects.text.scss
+++ b/source/scss/_library/_objects.text.scss
@@ -426,14 +426,6 @@ a.o-kicker {
   a {
     padding-bottom: 0;
     display: inline;
-    color: $c-white;
-    border-bottom: 2px dotted $c-white;
-
-    &:hover {
-      color: $c-white;
-      background-color: $c-primary;
-    }
-
   }
 }
 


### PR DESCRIPTION
Removed style changes for Gallery Overlay credit links from source/scss/_library/_objects.text.scss
And moved them to source/scss/_library/_module.gallery.scss so they do not affect the credit links on other article pages