### PR TITLE
image caption styles

### DIFF
--- a/source/scss/_library/_objects.leads.scss
+++ b/source/scss/_library/_objects.leads.scss
@@ -41,10 +41,6 @@
     }
   }
 
-  .o-icon--dashed-arrow {
-    margin-top: 2px;
-  }
-
   &__title {
     font-size: $font-size-m;
   }

--- a/source/scss/_library/_objects.text.scss
+++ b/source/scss/_library/_objects.text.scss
@@ -392,18 +392,11 @@ a.o-kicker {
  */
 .o-caption {
 
-  p {
+  p,
+  &__text {
     font-size: 14px; // Not in type scale
     font-family: $ff-font--tertiary;
     line-height: 1.5;
-  }
-
-  // ember compat <-- I see this is for Ember compatibility, but I had a bug
-  // regarding captions and this is what was breaking it. Perhaps there's
-  // another way to achieve compatibility - TJ
-  &__text {
-    //display: flex;
-    //align-items: center;
   }
 
   .o-icon--dashed-arrow {


### PR DESCRIPTION
Hey @tpitre, I was seeing some discrepencies in article templates w/r/t how images are treated in the lead asset position vs embedded in an article. The mark up on pattern lab is different for the two positions, but we're going to have the same mark up in the app b/c they're pulling from the same component.

### image in a lead position
![image](https://user-images.githubusercontent.com/2090382/62055640-08d2b100-b1ea-11e9-99d5-951ec25459f5.png)

### image in article body
![image](https://user-images.githubusercontent.com/2090382/62055562-d88b1280-b1e9-11e9-94dd-17dae3d162e0.png)

I also saw some differences in the image caption styles when compared to zeplin. I think this PR should resolve those issues, and hopefully overcome the markup differences as well.

