### PR TITLE
Adding z-index to back to top to appear above takeover ads. 

### DIFF
--- a/source/scss/_library/_objects.text.scss
+++ b/source/scss/_library/_objects.text.scss
@@ -440,6 +440,8 @@ a.o-kicker {
   margin: $space-double auto;
   display: flex;
   align-items: center;
+  position: relative;
+  z-index: $z-index-to-top;
 
   // Temporary until i can get the real icon
   .o-icon--up-arrow {

--- a/source/scss/_library/_settings.z-index.scss
+++ b/source/scss/_library/_settings.z-index.scss
@@ -39,3 +39,4 @@ $z-index-floating-header:    $z-index-50;
 $z-index-toggle-box-content: $z-index-50;
 
 $z-index-mq-display:  $z-index-100;
+$z-index-to-top:  $z-index-100;


### PR DESCRIPTION
Closes [DS-421](https://jira.wnyc.org/browse/DS-421)