### PR TITLE
CMS-583 Refactor to move banners out of home page content area

### DIFF
--- a/source/_patterns/04-templates/home.twig
+++ b/source/_patterns/04-templates/home.twig
@@ -11,13 +11,13 @@
     %}
   </div>
 
-  <div class="c-home__banners u-section-spacing--wide l-container l-container--xl l-wrap u-trigger-floating-header">
+  <div class="c-banners u-section-spacing--wide l-container l-container--xl l-wrap u-trigger-floating-header">
     {% if marketing_banner %}
       {% include '@molecules/banners/box-banner.twig' %}
     {% endif %}
 
     {% if breaking_news %}
-      <div class="l-container l-container--16col">
+      <div class="c-banners__breaking-news l-container l-container--16col">
         {% include '@molecules/banners/text-banner.twig' %}
       </div>
     {% endif %}

--- a/source/_patterns/04-templates/home.twig
+++ b/source/_patterns/04-templates/home.twig
@@ -11,8 +11,7 @@
     %}
   </div>
 
-  <div class="c-home__sections u-section-spacing--wide l-container l-container--xl l-wrap u-trigger-floating-header">
-
+  <div class="c-home__banners u-section-spacing--wide l-container l-container--xl l-wrap u-trigger-floating-header">
     {% if marketing_banner %}
       {% include '@molecules/banners/box-banner.twig' %}
     {% endif %}
@@ -22,6 +21,9 @@
         {% include '@molecules/banners/text-banner.twig' %}
       </div>
     {% endif %}
+  </div>
+
+  <div class="c-home__content-top u-section-spacing--wide l-container l-container--xl l-wrap">
 
     {% block featured_blocks_primary %}
       {% include '@organisms/sections/featured-block-list.twig' with featured_blocks_primary %}
@@ -61,11 +63,11 @@
 
   </div>
 
-  <div class="c-home__sections">
+  <div class="c-home__tout">
     {% include 'organisms-donate' with { "donate_classes": "c-donate-tout--static" } %}
   </div>
 
-  <div class="c-home__sections u-spacing--quad l-container l-wrap">
+  <div class="c-home__content-bottom u-spacing--quad l-container l-wrap">
 
     <div class="l-container l-container--14col u-spacing--triple">
       {% block block_section_4 %}

--- a/source/scss/_library/_objects.sections.scss
+++ b/source/scss/_library/_objects.sections.scss
@@ -114,14 +114,7 @@
   }
 }
 
-// Homepage structure:
-//
-// banners (breaking news, product marketing)
-// content-top
-// tout (donation ask)
-// content-bottom
-
-.c-home__banners {
+.c-banners {
   padding-top: $space-double;
 
   .l-container:only-child {
@@ -133,9 +126,7 @@
   }
 }
 
-// .c-home__content-top {
-
-// }
+// .c-home__content-top {}
 
 .c-home__tout {
   padding-top: $space-double;

--- a/source/scss/_library/_objects.sections.scss
+++ b/source/scss/_library/_objects.sections.scss
@@ -114,32 +114,47 @@
   }
 }
 
-.c-home {
-  &__sections {
-    padding-top: $space-double;
+// Homepage structure:
+//
+// banners (breaking news, product marketing)
+// content-top
+// tout (donation ask)
+// content-bottom
 
-    .o-box-banner + .c-featured-blocks {
-      margin-top: 0;
-    }
+.c-home__banners {
+  padding-top: $space-double;
 
-    .o-box-banner {
-      margin-bottom: 50px;
-    }
+  .l-container:only-child {
+    margin-bottom: $space-double;
+  }
 
-    @include media('>medium') {
+  .o-box-banner {
+    margin-bottom: 50px;
+  }
+}
 
-      &:not(.u-section-spacing--wide) {
-        padding-top: $space-triple;
-      }
-    }
+// .c-home__content-top {
 
-    .c-donate-tout--static {
-      @include media('<=medium') {
-        margin-top: 70px;
-      }
+// }
+
+.c-home__tout {
+  padding-top: $space-double;
+
+  .c-donate-tout--static {
+    @include media('<=medium') {
+      margin-top: 70px;
     }
   }
 }
+
+.c-home__content-bottom {
+  padding-top: $space-double;
+
+  @include media('>medium') {
+    padding-top: $space-triple;
+  }
+}
+
 
 
 /**

--- a/source/scss/_library/_objects.sections.scss
+++ b/source/scss/_library/_objects.sections.scss
@@ -117,7 +117,7 @@
 .c-banners {
   padding-top: $space-double;
 
-  .l-container:only-child {
+  .c-banners__breaking-news:last-child {
     margin-bottom: $space-double;
   }
 
@@ -126,7 +126,12 @@
   }
 }
 
-// .c-home__content-top {}
+/**
+ * Homepage structure:
+ *  - content-top
+ *  - tout (donation ask)
+ *  - content-bottom
+ */
 
 .c-home__tout {
   padding-top: $space-double;


### PR DESCRIPTION
Refactor to move banners out of home page content area, so we can put these banners on all pages more easily.  This shouldn't change existing spacing on the home page.

Also renamed the `.c-home__sections` blocks to individual sections (`content-top,tout,content-bottom`) since they all had different rules and don't really feel like similar kinds of things.

https://jira.wnyc.org/browse/CMS-583